### PR TITLE
Enforce invocation of Interface Stubs

### DIFF
--- a/src/main/kotlin/com/prestongarno/ktq/QSchemaType.kt
+++ b/src/main/kotlin/com/prestongarno/ktq/QSchemaType.kt
@@ -127,24 +127,6 @@ interface QSchemaType {
     }
   }
 
-  object QCustomScalar {
-    /**
-     * Method which provides a delegate for {@link com.prestongarno.ktq.CustomScalar} fields
-     * fragment schema-defined scalar types
-     * @param T The type argument for the createStub, typedValueFrom a schema-defined CustomScalar type
-     * @return Grub<CustomScalarInitStub<T>> the delegate which lazily provides a CustomScalarInitStub<T> */
-    //inline fun <reified T : CustomScalar> stub(): StubProvider<CustomScalarInitStub<T>> = createCustomScalarStub(T::class.simpleName!!)
-
-    /**
-     * Method which provides a delegate for {@link com.prestongarno.ktq.CustomScalar} fields
-     * fragment schema-defined scalar types which take input argBuilder
-     * @param arginit an initializer for the createStub field. <b>Important for auto-generated schema definitions</b>
-     * @param T type of the custom scalar
-     * @param A type argument for the argument builder class for that given schema field definition
-     * @return Grub<CustomScalarConfigStub<T, A>> the delegate which lazily provides a CustomScalarConfigStub<T, A> */
-    //inline fun <reified T : CustomScalar, A : ArgBuilder> configStub(): StubProvider<CustomScalarConfigStub<T, A>> = createCustomScalarConfig(T::class.simpleName!!)
-  }
-
   object QTypes {
 
     inline fun <reified T : QType> stub(): StubProvider<TypeStub.Query<T>> =
@@ -155,6 +137,23 @@ interface QSchemaType {
 
     inline fun <reified T : QType, A : ArgBuilder> configStub(): StubProvider<TypeStub.ConfigurableQuery<T, A>> =
         Grub(T::class.graphQlName()) { TypeStub.argStub<T, A>(it) }
+
+  }
+
+  object QTypeList {
+
+    inline fun <reified T : QType> stub()
+        : StubProvider<TypeListStub.Query<T>> =
+        Grub(T::class.graphQlName(), true) { TypeListStub.noArgStub<T>(it) }
+
+    inline fun <reified T : QType, A : ArgBuilder> optionalConfigStub()
+        : StubProvider<TypeListStub.OptionalConfigQuery<T, A>> =
+        Grub(T::class.graphQlName(), true) { TypeListStub.optionalArgStub<T, A>(it) }
+
+    inline fun <reified T : QType, A : ArgBuilder> configStub()
+        : StubProvider<TypeListStub.ConfigurableQuery<T, A>> =
+        Grub(T::class.graphQlName(), true) { TypeListStub.argStub<T, A>(it) }
+
   }
 
   object QInterfaces {
@@ -186,28 +185,8 @@ interface QSchemaType {
     inline fun <reified T, A> configStub(): StubProvider<InterfaceListStub.ConfigurableQuery<T, A>>
         where T : QType, T : QInterface, A : ArgBuilder =
         Grub(T::class.graphQlName(), true) { InterfaceListStub.argStub<T, A>(it) }
+
   }
-
-  object QTypeList {
-
-    inline fun <reified T : QType> stub()
-        : StubProvider<TypeListStub.Query<T>> =
-        Grub(T::class.graphQlName(), true) { TypeListStub.noArgStub<T>(it) }
-
-    inline fun <reified T : QType, A : ArgBuilder> optionalConfigStub()
-        : StubProvider<TypeListStub.OptionalConfigQuery<T, A>> =
-        Grub(T::class.graphQlName(), true) { TypeListStub.optionalArgStub<T, A>(it) }
-
-    inline fun <reified T : QType, A : ArgBuilder> configStub()
-        : StubProvider<TypeListStub.ConfigurableQuery<T, A>> =
-        Grub(T::class.graphQlName(), true) { TypeListStub.argStub<T, A>(it) }
-  }
-
-  object QCustomScalarList
-
-  object QUnion
-
-  object QUnionList
 
   object QEnum {
     inline fun <reified T> stub(): StubProvider<NoArgConfig<EnumStub<T, ArgBuilder>, T>> where T : Enum<*>, T : QEnumType
@@ -239,6 +218,14 @@ interface QSchemaType {
         Grub(T::class.graphQlName(), true) { EnumListStub.argStub<T, A>(it, T::class) }
 
   }
+
+  object QCustomScalar
+
+  object QCustomScalarList
+
+  object QUnion
+
+  object QUnionList
 
 }
 

--- a/src/main/kotlin/com/prestongarno/ktq/Resolvers.kt
+++ b/src/main/kotlin/com/prestongarno/ktq/Resolvers.kt
@@ -2,6 +2,7 @@ package com.prestongarno.ktq
 
 import com.prestongarno.ktq.adapters.Adapter
 import com.prestongarno.ktq.adapters.formatAs
+import com.prestongarno.ktq.hooks.FragmentContext
 import com.prestongarno.ktq.hooks.ModelProvider
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
@@ -58,8 +59,7 @@ fun String.indent(times: Int = 1): String =
 fun String.prepend(of: String): String = of + this
 
 internal fun QModel<*>.prettyPrinted(indentation: Int): String =
-    if (model is QUnionType) prettyPrintUnion(indentation) else
-      ((getFields().joinToString(separator = ",\n") { it.prettyPrinted() }
+    ((getFields().joinToString(separator = ",\n") { it.prettyPrinted() }
           .indent(1)) + "\n}").prepend("{\n").indent(indentation)
           .replace("\\s*([(,])".toRegex(), "$1").trim()
 
@@ -78,6 +78,9 @@ internal fun Adapter.prettyPrinted(): String = qproperty.graphqlName +
             "${it.key}: ${formatAs(it.value)}"
           }
       this is ModelProvider -> value.toGraphql()
+      this is FragmentContext -> fragments.joinToString("\n") {
+        "... on ${qproperty.graphqlType} ${it.model.toGraphql(true)}"
+      }
       else -> ""
     }).replace("\\s*([(,])".toRegex(), "$1").trim()
 

--- a/src/main/kotlin/com/prestongarno/ktq/properties/GraphQlProperty.kt
+++ b/src/main/kotlin/com/prestongarno/ktq/properties/GraphQlProperty.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KProperty
  *
  * <b>** NOTE ** </b>: This property does NOT represent the field name & type on the property that
  * the adapter holding this object represents!!! It references the information defined in
- * the GraphQL Schema. The name of the property it returns to does not need to be the same as [graphqlName]! */
+ * the GraphQL Schema. The name of the property it returns may not be the same as the property on the actual model! */
 interface GraphQlProperty {
 
   /**

--- a/src/test/kotlin/com/prestongarno/ktq/primitives/BasicPrimitiveArray.kt
+++ b/src/test/kotlin/com/prestongarno/ktq/primitives/BasicPrimitiveArray.kt
@@ -106,5 +106,6 @@ class BasicPrimitiveArray {
     query.toGraphql(false) eq
         """{studentNames(Hello: \"World\"),studentAges(NumberArgument: 9000),""" +
           """studentGpa(BooleanArgument: true),studentPassing(FloatArgument: 5.005f)}"""
+    println(query.toGraphql())
   }
 }

--- a/src/test/kotlin/com/prestongarno/ktq/type/TypeStubQuery.kt
+++ b/src/test/kotlin/com/prestongarno/ktq/type/TypeStubQuery.kt
@@ -53,7 +53,7 @@ enum class State : QEnumType {
   CA
 }
 
-class TypeStubQuery {
+class TypeStubQueryable {
 
   class Me : QModel<Person>(Person) {
     val name by model.name {

--- a/src/test/kotlin/com/prestongarno/ktq/type/TypeStubQuery.kt
+++ b/src/test/kotlin/com/prestongarno/ktq/type/TypeStubQuery.kt
@@ -1,5 +1,5 @@
 package com.prestongarno.ktq.type
-/*
+
 import com.google.common.truth.Truth.assertThat
 import com.prestongarno.ktq.ArgBuilder
 import com.prestongarno.ktq.QEnumType
@@ -30,17 +30,17 @@ object Order : QType {
 }
 
 object Person : QType {
-  val name by QScalar.stringStub()
+  val name by QScalar.String.stub()
 }
 
 object Address : QType {
-  val line1 by QScalar.stringStub()
+  val line1 by QScalar.String.stub()
 
-  val city by QScalar.stringStub()
+  val city by QScalar.String.stub()
 
   val state by QEnum.stub<State>()
 
-  val zip by QScalar.intStub()
+  val zip by QScalar.Int.stub()
 }
 
 enum class ContactAddressType : QEnumType {
@@ -208,4 +208,4 @@ class TypeStubQuery {
     assertThat(query.destinationAddress.lineOne)
         .isEqualTo("1234 GraphQL")
   }
-}*/
+}


### PR DESCRIPTION
This encourages configuring fragments for interface fields.

Before, this was possible:

```interface Person : QInterface, QType {
    val foo: StringDelegate.Query
}

object Foo : QType {
  
  val personField: QType.stub<Person>()

}

class IllegalGraphQL : QModel<Foo>() {
  
  val person by model.personField

}
```



Now, it requires this:

        val person by model.personField {
           on { /* () -> ConcretePerson */ }
        }