### PR TITLE
Extension additions

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -1,0 +1,3 @@
+# <b><span style="color:#f442c2">DSL Tutorial</span></b>
+
+// TODO: Take a look at the tests in the DSL modules for examples of fragments & how to use them until then

--- a/jvm/src/main/kotlin/Api.kt
+++ b/jvm/src/main/kotlin/Api.kt
@@ -7,4 +7,9 @@ package org.kotlinq.jvm
 inline fun <reified T : Data?> fragment(
     noinline init: (GraphQlResult) -> T,
     noinline block: TypedFragmentScope<T>.() -> Unit = { /* nothing */ }
-) = ClassFragment(T::class, init, block)
+): ClassFragment<T> = ClassFragment(T::class, init, block)
+
+
+inline operator fun <reified T : Data?> ((GraphQlResult) -> T).invoke(
+    noinline block: TypedFragmentScope<T>.() -> Unit
+): ClassFragment<T> = ClassFragment(T::class, this, block)

--- a/jvm/src/main/kotlin/Reflekt.kt
+++ b/jvm/src/main/kotlin/Reflekt.kt
@@ -49,15 +49,22 @@ private fun listIsCompatible(value: List<*>, type: KType): Boolean {
 }
 
 @PublishedApi internal
-fun KProperty1<*, Data?>.toPropertyInfo(
-    typeName: String,
+fun KProperty1<*, *>.toPropertyInfo(
+    typeName: String = this.returnType.rootType.clazz?.simpleName!!,
     args: Map<String, Any> = emptyMap()
-) = PropertyInfo.propertyNamed(name)
-    .typeKind(wrap(
-        Kind.typeNamed(typeName),
-        returnType)
-    ).arguments(args)
-    .build()
+): PropertyInfo {
+
+  if (returnType.rootType.scalarKind() != null)
+    throw IllegalArgumentException(this.toString())
+
+  return PropertyInfo
+      .propertyNamed(name)
+      .typeKind(wrap(
+          Kind.typeNamed(typeName),
+          returnType))
+      .arguments(args)
+      .build()
+}
 
 
 internal

--- a/jvm/src/test/kotlin/ClassFragmentDsl.kt
+++ b/jvm/src/test/kotlin/ClassFragmentDsl.kt
@@ -1,0 +1,50 @@
+package org.kotlinq.jvm
+
+import org.junit.Test
+
+
+class ClassFragmentDsl {
+
+  @Test fun syntaxIsReadable() {
+
+    class N2Entity(result: GraphQlResult)
+      : Data by result.toData() {
+      val x by result.integer()
+    }
+
+    class NestedEntity(result: GraphQlResult)
+      : Data by result.toData() {
+      val integerField by result.integer()
+      val floatingPointArrayField by result.floatingPoint().asList()
+      val foo by result<N2Entity>().asList()
+    }
+    class MyEntity(result: GraphQlResult)
+      : Data by result.toData() {
+      val stringField by result.string()
+      val nestedEntity by result<NestedEntity>()
+    }
+
+    val entityFragment = ::MyEntity {
+      MyEntity::nestedEntity on ::NestedEntity {
+        NestedEntity::foo spread ::N2Entity
+      }
+    }
+
+    val actual = entityFragment.toGraphQl(
+        pretty = true,
+        idAndTypeName = false)
+    val expect = """
+      |{
+      |  nestedEntity {
+      |    floatingPointArrayField
+      |    foo {
+      |      x
+      |    }
+      |    integerField
+      |  }
+      |  stringField
+      |}
+      """.trimMargin("|")
+    require(actual == expect) { "Not equal: <$expect> != <$actual>"}
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ markdown_extensions:
 pages:
   - Intro: index.md
   - Overview: core.md
+  - DSL Tutorial: dsl.md
   - Contributing: contributing.md
   - License: license.md
 


### PR DESCRIPTION
* Extensions for inline fragment declarations on simple types within DSL scope
* Top-level extension operator fun `((GraphQlResult) -> T).invoke(block: TypedFragmentScope<T>.() -> Unit`